### PR TITLE
Showing spinner in a setTimeout function to avoid blinking spinners

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# shinycssloaders 1.0.1 (2021-03-09)
+- Add support to delay display
+
 # shinycssloaders 1.0.0 (2020-07-28)
 
 - Add support for custom images with `image` parameter (#46)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# shinycssloaders 1.0.1 (2021-03-09)
+# Unreleased version
+
+- Fix page sometimes wobbling because of hidden spinner (#54)
 - Add support to delay display
 
 # shinycssloaders 1.0.0 (2020-07-28)

--- a/R/withSpinner.R
+++ b/R/withSpinner.R
@@ -46,7 +46,8 @@ withSpinner <- function(
   proxy.height = NULL,
   id = NULL,
   image = NULL, image.width = NULL, image.height = NULL,
-  hide.ui = TRUE
+  hide.ui = TRUE,
+  show.delay = 0
 ) {
   stopifnot(type %in% 0:8)
   
@@ -113,6 +114,9 @@ withSpinner <- function(
         "shiny-spinner-output-container",
         if (hide.ui) "shiny-spinner-hideui" else "",
         if (is.null(image)) "" else "shiny-spinner-custom"
+      ),
+      `data-showdelay` = paste(
+        if (is.numeric(show.delay)) show.delay else "0"
       ),
       shiny::div(
         class = paste(

--- a/inst/assets/spinner.js
+++ b/inst/assets/spinner.js
@@ -1,6 +1,6 @@
 (function() {
 var output_states = {};
-var timeoutHandles = {};
+var timeout_handles = {};
 
 function escapeSelector(s) {
     return s.replace(/([!"#$%&'()*+,-./:;<=>?@\[\\\]^`{|}~])/g, "\\$1");
@@ -10,10 +10,10 @@ function show_spinner(id) {
     var selector = "#" + escapeSelector(id);
     var parent = $(selector).closest(".shiny-spinner-output-container");
     
-    if (parent && parent.length && (timeoutHandles[parent] === null || timeoutHandles[parent] === undefined)) {
+    if (parent && parent.length && (timeout_handles[parent] === null || timeout_handles[parent] === undefined)) {
         var delay = parent.data() && parent.data().showdelay ? parent.data().showdelay : 0;
-        timeoutHandles[parent] = setTimeout(function(){
-          timeoutHandles[parent] = null;
+        timeout_handles[parent] = setTimeout(function(){
+          timeout_handles[parent] = null;
           
           $(selector).siblings(".load-container, .shiny-spinner-placeholder").removeClass('shiny-spinner-hidden');
     
@@ -31,9 +31,9 @@ function hide_spinner(id) {
     var selector = "#" + escapeSelector(id);
     var parent = $(selector).closest(".shiny-spinner-output-container");
     
-    if (parent && parent.length &&  timeoutHandles[parent] !== null) {
-      clearTimeout(timeoutHandles[parent]);
-      timeoutHandles[parent] = null;
+    if (parent && parent.length &&  timeout_handles[parent] !== null) {
+      clearTimeout(timeout_handles[parent]);
+      timeout_handles[parent] = null;
     }
     
     $(selector).siblings(".load-container, .shiny-spinner-placeholder").addClass('shiny-spinner-hidden');

--- a/inst/assets/spinner.js
+++ b/inst/assets/spinner.js
@@ -10,7 +10,7 @@ function show_spinner(id) {
     var selector = "#" + escapeSelector(id);
     var parent = $(selector).closest(".shiny-spinner-output-container");
     
-    if (parent && parent.length && timeoutHandles[parent] === null) {
+    if (parent && parent.length && (timeoutHandles[parent] === null || timeoutHandles[parent] === undefined)) {
         var delay = parent.data() && parent.data().showdelay ? parent.data().showdelay : 0;
         timeoutHandles[parent] = setTimeout(function(){
           timeoutHandles[parent] = null;
@@ -23,7 +23,7 @@ function show_spinner(id) {
             $(selector).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output, .shiny-output-error').addClass('shiny-spinner-hidden');      
           }
           
-        }, delay)
+        }, delay);
     }
 }
 

--- a/inst/assets/spinner.js
+++ b/inst/assets/spinner.js
@@ -1,5 +1,6 @@
 (function() {
 var output_states = {};
+var timeoutHandles = {};
 
 function escapeSelector(s) {
     return s.replace(/([!"#$%&'()*+,-./:;<=>?@\[\\\]^`{|}~])/g, "\\$1");
@@ -8,18 +9,33 @@ function escapeSelector(s) {
 function show_spinner(id) {
     var selector = "#" + escapeSelector(id);
     var parent = $(selector).closest(".shiny-spinner-output-container");
-    $(selector).siblings(".load-container, .shiny-spinner-placeholder").removeClass('shiny-spinner-hidden');
     
-    if (parent.hasClass("shiny-spinner-hideui")) {
-      $(selector).siblings(".load-container").siblings('.shiny-bound-output, .shiny-output-error').css('visibility', 'hidden');
-      // if there is a proxy div, hide the previous output
-      $(selector).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output, .shiny-output-error').addClass('shiny-spinner-hidden');      
+    if (parent && parent.length && timeoutHandles[parent] === null) {
+        var delay = parent.data() && parent.data().showdelay ? parent.data().showdelay : 0;
+        timeoutHandles[parent] = setTimeout(function(){
+          timeoutHandles[parent] = null;
+          
+          $(selector).siblings(".load-container, .shiny-spinner-placeholder").removeClass('shiny-spinner-hidden');
+    
+          if (parent.hasClass("shiny-spinner-hideui")) {
+            $(selector).siblings(".load-container").siblings('.shiny-bound-output, .shiny-output-error').css('visibility', 'hidden');
+            // if there is a proxy div, hide the previous output
+            $(selector).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output, .shiny-output-error').addClass('shiny-spinner-hidden');      
+          }
+          
+        }, delay)
     }
 }
 
 function hide_spinner(id) {
     var selector = "#" + escapeSelector(id);
     var parent = $(selector).closest(".shiny-spinner-output-container");
+    
+    if (parent && parent.length &&  timeoutHandles[parent] !== null) {
+      clearTimeout(timeoutHandles[parent]);
+      timeoutHandles[parent] = null;
+    }
+    
     $(selector).siblings(".load-container, .shiny-spinner-placeholder").addClass('shiny-spinner-hidden');
     if (parent.hasClass("shiny-spinner-hideui")) {
       $(selector).siblings(".load-container").siblings('.shiny-bound-output').css('visibility', 'visible');

--- a/inst/examples/demo/server.R
+++ b/inst/examples/demo/server.R
@@ -1,7 +1,5 @@
 server <- function(input, output, session) {
   plotnum <- reactiveVal(0)
-  plotdata <- reactiveValues( data = runif(10) )
-
   
   output$show_example <- renderUI({
     if (input$type == "custom") {
@@ -9,8 +7,7 @@ server <- function(input, output, session) {
         ui_element = plotOutput(paste0("example", plotnum())),
         image = input$image,
         image.width = if (input$image_size_default) NULL else input$image.width,
-        image.height = if (input$image_size_default) NULL else input$image.height,
-        show.delay = input$delaytime
+        image.height = if (input$image_size_default) NULL else input$image.height
       )
     } else {
       params <- list(
@@ -18,10 +15,10 @@ server <- function(input, output, session) {
         type = as.numeric(input$type),
         color = input$col,
         size = input$size,
-        color.background = "#fafafa",
-        show.delay = input$delaytime
+        color.background = "#fafafa"
       )
     }
+    params$show.delay <- input$delay
     do.call(shinycssloaders::withSpinner, params)
   })
   
@@ -36,19 +33,9 @@ server <- function(input, output, session) {
       shinyjs::disable("params")
       on.exit(shinyjs::enable("params"))
       Sys.sleep(isolate(input$time))
-      plot(plotdata$data, main = "Random Plot")
+      plot(runif(10), main = "Random Plot")
       bg <- par(bg = bg)
     })
-  })
-  
-  observeEvent(input$refresh, ignoreNULL = FALSE, {
-    if (input$time > 5) {
-      shinyjs::alert("In order to not block my server for too long, please use a time of no more than 5 seconds")
-      return()
-    }
-
-    plotdata$data <- runif(10) 
-    Sys.sleep(isolate(input$time))
   })
   
 }

--- a/inst/examples/demo/server.R
+++ b/inst/examples/demo/server.R
@@ -1,5 +1,7 @@
 server <- function(input, output, session) {
   plotnum <- reactiveVal(0)
+  plotdata <- reactiveValues( data = runif(10) )
+
   
   output$show_example <- renderUI({
     if (input$type == "custom") {
@@ -7,7 +9,8 @@ server <- function(input, output, session) {
         ui_element = plotOutput(paste0("example", plotnum())),
         image = input$image,
         image.width = if (input$image_size_default) NULL else input$image.width,
-        image.height = if (input$image_size_default) NULL else input$image.height
+        image.height = if (input$image_size_default) NULL else input$image.height,
+        show.delay = input$delaytime
       )
     } else {
       params <- list(
@@ -15,7 +18,8 @@ server <- function(input, output, session) {
         type = as.numeric(input$type),
         color = input$col,
         size = input$size,
-        color.background = "#fafafa"
+        color.background = "#fafafa",
+        show.delay = input$delaytime
       )
     }
     do.call(shinycssloaders::withSpinner, params)
@@ -32,8 +36,19 @@ server <- function(input, output, session) {
       shinyjs::disable("params")
       on.exit(shinyjs::enable("params"))
       Sys.sleep(isolate(input$time))
-      plot(runif(10), main = "Random Plot")
+      plot(plotdata$data, main = "Random Plot")
       bg <- par(bg = bg)
     })
   })
+  
+  observeEvent(input$refresh, ignoreNULL = FALSE, {
+    if (input$time > 5) {
+      shinyjs::alert("In order to not block my server for too long, please use a time of no more than 5 seconds")
+      return()
+    }
+
+    plotdata$data <- runif(10) 
+    Sys.sleep(isolate(input$time))
+  })
+  
 }

--- a/inst/examples/demo/ui.R
+++ b/inst/examples/demo/ui.R
@@ -82,8 +82,7 @@ fluidPage(
       ),
       numericInput("time", "Seconds to show spinner", 1.5),
       numericInput("delaytime", "Milliseconds to delay show spinner", 100),
-      actionButton("update", "Update", class = "btn-primary btn-lg"),
-      actionButton("refresh", "Refresh Data", class = "btn-primary btn-lg"),
+      actionButton("update", "Update", class = "btn-primary btn-lg")
     ),
     column(
       6,

--- a/inst/examples/demo/ui.R
+++ b/inst/examples/demo/ui.R
@@ -81,7 +81,7 @@ fluidPage(
         sliderInput("size", "Size", min = 0.5, max = 5, step = 0.5, value = 1)
       ),
       numericInput("time", "Seconds to show spinner", 1.5),
-      numericInput("delaytime", "Milliseconds to delay show spinner", 100),
+      numericInput("delay", "Delay before showing spinner (milliseconds)", 0),
       actionButton("update", "Update", class = "btn-primary btn-lg")
     ),
     column(

--- a/inst/examples/demo/ui.R
+++ b/inst/examples/demo/ui.R
@@ -81,7 +81,9 @@ fluidPage(
         sliderInput("size", "Size", min = 0.5, max = 5, step = 0.5, value = 1)
       ),
       numericInput("time", "Seconds to show spinner", 1.5),
+      numericInput("delaytime", "Milliseconds to delay show spinner", 100),
       actionButton("update", "Update", class = "btn-primary btn-lg"),
+      actionButton("refresh", "Refresh Data", class = "btn-primary btn-lg"),
     ),
     column(
       6,


### PR DESCRIPTION
Adding configurable delay (_show.delay_ property) before showing spinner (and if a _hide_ comes before delay, it doesn't show at all).

Default values should behave almost* the same as before: with a 0 delay timeout function it can be that the show/hide cycle behaves differently, but on my understanding it would behave better (e.g.: if somehow the hide spinner happens immediately after the display, nothing will happen while before the change the dom would be affected twice)

Split from pull request #61 

Added one more button to example, to allow a test where only the data is updated - setting sleep time to 0 one can see how the show.delay can be used 