### PR TITLE
add fill_container argument for a responsive spinner ui container

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,11 +21,11 @@ Imports:
     digest,
     glue,
     grDevices,
-    htmltools (>= 0.3.5),
+    htmltools (>= 0.5.4),
     shiny
 Suggests:
     shinydisconnect,
     shinyjs
-RoxygenNote: 7.1.0
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/R/withSpinner.R
+++ b/R/withSpinner.R
@@ -18,6 +18,8 @@
 #' size of the image is used. Ignored if not using `image`.
 #' @param hide.ui By default, while an output is recalculating, the output UI is hidden and the spinner is visible instead.
 #' Setting `hide.ui = FALSE` will result in the spinner showing up on top of the previous output UI.
+#' @param fill_container By default, the spinner UI container height is fixed to the proxy.height
+#' Setting `fill_container = TRUE` will allow the spinner UI container to grow and shrink with their parent container
 #' @examples
 #' if (interactive()) {
 #'   library(shiny)
@@ -46,7 +48,8 @@ withSpinner <- function(
   proxy.height = NULL,
   id = NULL,
   image = NULL, image.width = NULL, image.height = NULL,
-  hide.ui = TRUE
+  hide.ui = TRUE,
+  fill_container = FALSE
 ) {
   
   if (!inherits(ui_element, "shiny.tag") && !inherits(ui_element, "shiny.tag.list")) {
@@ -126,7 +129,8 @@ withSpinner <- function(
       class = paste(
         "shiny-spinner-output-container",
         if (hide.ui) "shiny-spinner-hideui" else "",
-        if (is.null(image)) "" else "shiny-spinner-custom"
+        if (is.null(image)) "" else "shiny-spinner-custom",
+        if(fill_container) "html-fill-item html-fill-container" else ""
       ),
       shiny::div(
         class = paste(

--- a/man/withSpinner.Rd
+++ b/man/withSpinner.Rd
@@ -16,7 +16,8 @@ withSpinner(
   image = NULL,
   image.width = NULL,
   image.height = NULL,
-  hide.ui = TRUE
+  hide.ui = TRUE,
+  fill_container = FALSE
 )
 }
 \arguments{
@@ -49,6 +50,9 @@ size of the image is used. Ignored if not using \code{image}.}
 
 \item{hide.ui}{By default, while an output is recalculating, the output UI is hidden and the spinner is visible instead.
 Setting \code{hide.ui = FALSE} will result in the spinner showing up on top of the previous output UI.}
+
+\item{fill_container}{By default, the spinner UI container height is fixed to the proxy.height
+Setting \code{fill_container = TRUE} will allow the spinner UI container to grow and shrink with their parent container}
 }
 \description{
 Add a spinner that shows when an output is recalculating


### PR DESCRIPTION
Hi Dean,

Related to #76, I investigated the issue and it turns out that [htmltools 0.5.4](https://github.com/rstudio/htmltools/releases/tag/v0.5.4) added some new css classes that "are allowed to grow and shrink when their parent is opinionated about their height". The two main classes are "html-fill-item" and  "html-fill-container". 

So, I added a boolean argument to the _withSpinner_ function that appends these css classes to the spinner container. 
Obviously this requires to import the more recent htmltools update (>= 0.5.4).

![Screenshot 2023-02-01 at 5 54 35 PM](https://user-images.githubusercontent.com/37287792/216211985-7f63e55c-eb43-4bba-91fc-ed5c8744d568.png)
![Screenshot 2023-02-01 at 5 54 51 PM](https://user-images.githubusercontent.com/37287792/216211988-8fcfb687-2cb1-4a59-8735-d235df62e859.png)


Reprex:

```
library(shiny)
library(shinycssloaders)
library(plotly)
library(bslib)

ui <- page_fluid(
  card(
    full_screen = T,
    card_header("fill_container = F"),
    card_body_fill(withSpinner(plotlyOutput("plot1"), fill_container = F))
  ),
  card(
    full_screen = T,
    card_header("fill_container = T"),
    card_body_fill(withSpinner(plotlyOutput("plot2"), fill_container = T))
  ),
)

server <- function(input, output) {
  
  output$plot1 <- renderPlotly({
    plot_ly(mtcars, x = ~mpg, y = ~cyl) |> add_markers()
  })
  
  output$plot2 <- renderPlotly({
    plot_ly(mtcars, x = ~mpg, y = ~cyl) |> add_markers()
  })
  
}

shinyApp(ui, server)
```

Let me know if this is a good addition to the shinycssloaders package. 

Also, this might help get rid of the proxy.height argument since the spinner will always fit the children? But I'm not sure about that since I haven't done enough with the proxy.height argument

Best,
Khaled
